### PR TITLE
readme: remove references to only supporting ST 2

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1,8 +1,8 @@
 ============================
-Sort Tabs for Sublime Text 2
+Sort Tabs for Sublime Text
 ============================
 
-This plugin sort the tabs in Sublime Text 2 using one of these methods:
+This plugin sort the tabs in Sublime Text using one of these methods:
 
 - Sort Tabs by file name
 - Sort Tabs by file type


### PR DESCRIPTION
I'm currently using this plugin perfectly fine in Sublime Text 4 but the Github project and Package Control webpages have a description "Sort Tabs for Sublime Text 2" that confuse people into thinking this is for ST 2  only.

Github project description and PackageControl page descriptions cannot be fixed via commit I guess, should be done by repo owner.